### PR TITLE
Adding 2 Uno Sketches for Maxbotix Distance Sensor testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ might find it helpful.
 
 #### Maxbotix
 
-* LV-MaxSonar-EZ4
+* LV-MaxSonar-EZ4 
+* HRLV family
+
+2 Uno Sketch files: 
+one for Analog Voltage measurement of distance **UnoMaxbotixAnalogMode.ino** 
+and one sketch for Pulse Duration method of distance measurement **UnoMaxbotixPulseTimeMode.ino** 
+
+Both sketches have #if 1 compiler switches in them, to allow you to use either the EZ or HRLV families of Maxbotix ultrasonic distance sensors. Set the #if to 1 to allow the EZ family and set the #if to 0 to use the HRLV family. The compiler switches are similar to #define or #ifdef #else #endif statements, read up on compiler if confused.
+
+EZ sensors I tested with were the MB1040 only. 
+HRLV sensor I tested with were the MB1013 MB1023 and MB1033. 
+
+The reason a compiler switch was used is that the EZ is less precise, and so uses different scaling factor. Interesting fact is that this code uses the statistical mode/mean functions borrowed from Adafruit, thereby throwing out most erroneous readings.
+I think the EZ accuracy is about 1inch, whereas the HRLV has about 5mm precision (5x that of the EZ).
+Note you will find that if you use the Analog voltage method, you will have to calibrate your readings for EACH SENSOR, whereas if you use Pulse duration pin and methods, you will not have to calibrate (at least that's what I found).
 
 #### Rockwell Automation
 

--- a/UnoMaxbotixAnalogMode.ino
+++ b/UnoMaxbotixAnalogMode.ino
@@ -1,0 +1,137 @@
+/* uno reading maxbotix proximity sensors
+
+   modified by jec to support maxbotix sensor
+  adding display printouts, and serial monitor is still there.
+   
+   The circuit:
+  * +V to maxbotix to V pin of UNO
+  * GND connection of the maxbotix attached to ground of UNO
+  * AN(analog out) connection of the maxbotix  attached to unconnected as we are using pulse width output
+  * PWO pulse width output connection of the maxbotix  attached to digital pin 7 of UNO
+  * no resistors needed with UNO as it's 5 volt native unless you switch it to 3.3V.
+
+NOTE you must customize the sensor type. The EZ models have different scaling factors than the HRLV models.
+See #ifdef sections in loop
+
+   refer to 
+   https://learn.adafruit.com/trinket-ultrasonic-rangefinder/debugging-and-going-further?view=all
+   https://learn.adafruit.com/ultrasonic-ruler/overview?view=all
+   
+   
+ */
+/* Board settings 
+ *  board: uno
+ *  CPU 80Mhz
+ *  flash: 4M (3M SPIFFS) 
+ *  upload speed: 115200
+ *  programmer AVRISP mkII
+ *  */
+#include <Wire.h>
+
+
+// this constant won't change.  It's the pin number
+// of the sensor's output:
+//const int pingPin = 7;
+const int EZ1pin = A1;  // maxbotix analog voltage out pin. see loop() section for different scaling depending on sensor.
+int8_t arraysize = 9; // quantity of values to find the median (sample size). Needs to be an odd number
+//declare an array to store the samples. not necessary to zero the array values here, it just makes the code clearer
+uint16_t rangevalue[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0};
+uint16_t modE;        // calculated median distance
+
+float VCC=5000.0; // mv here, and mv from analog read.. keep same units.
+    // ===== EZ such as MB1040, it is 58uS per mm for range up to 6.45m with 1 inch resolution
+    //Pin 2-PW- This pin outputs a pulse width representation of range. 
+    //The distance can be calculated using the scale factor of 147uS per inch.
+    //Pin 3-AN- Outputs analog voltage with a scaling factor of (Vcc/512) per inch. 
+    //A supply of 5V yields ~9.8mV/in = 3.85mV/cm. and 3.3V yields ~6.4mV/in. 
+    //The output is buffered and corresponds to the most recent range data.
+    //Change to ZERO if you don't have an EZ model.
+#if 0  // put 1 here if you using EZ models, and a 0 here if you using HRLV models
+//float scalingFactor; // = (VCC / 512 )/2.54  ; // for greenboard maxbotix maxsonar ez, volts per cm
+float scalingFactor = 0.77519; // for 5V VCC, and cm conversions. 
+#else
+    // ===== HRLV such as 1013, 1023, 1033, it is 1uS per mm for range up to 5000mm with 1mm resolution
+    //Pin 2- Pulse Width Output: This pin outputs a pulse width representation of the distance with a scale factor 
+    //of 1uS per mm. Output range is 300uS for 300-mm to 5000uS for 5000-mm. Pulse width output is +/- 1% of 
+    //the serial data sent.
+    //Pin 3- Analog Voltage Output: On power-up, the voltage on this pin is set to 0V, after which, the voltage 
+    //on this pin has the voltage corresponding to the latest measured distance. 
+    //This pin outputs an analog voltage scaled representation of the distance with a scale factor of (Vcc/1024) per 5-mm.
+    //Actually, just multiply the number of bits in the value by 5 to yield the range in mm
+float scalingFactor = VCC / 1024  /2.466 ; // for blackboard maxbotix maxsonar HRLV, !! volts per cm for HRLV models
+// VCC/1024 = volts / 5mm but i div by 2 to make it volts/cm
+#endif
+
+void setup() {
+  // initialize serial communication:
+  Serial.begin(9600);
+  // wake screen
+  Serial.print("Analog voltage test Maxbotix ");
+  //pinMode(EZ1pin, INPUT); // Set ultrasonic sensor pin as input
+}
+
+
+
+void loop() {
+ 
+  String stringOut = ": ";
+  
+  // read the input on analog pin 1 is gryo temp: (value is mV)
+  float tempIn = analogRead(EZ1pin);
+  // Convert the analog reading (which goes from 0 - 1023) to a voltage (0 - 5V):
+  float distance = tempIn / scalingFactor;
+
+  Serial.print("distance is: ");
+  stringOut += distance;
+  stringOut += " cm, raw: ";
+  stringOut += tempIn;
+  Serial.println(stringOut);
+
+  delay(500);                        // Read every half second
+}
+
+// Sorting function (Author: Bill Gentles, Nov. 12, 2010)
+void isort(uint16_t *a, int8_t n){
+  for (int i = 1; i < n; ++i)  {
+    uint16_t j = a[i];
+    int k;
+    for (k = i - 1; (k >= 0) && (j < a[k]); k--) {
+      a[k + 1] = a[k];
+    }
+    a[k + 1] = j;
+  }
+}
+
+// Mode function, returning the mode or median.
+uint16_t mode(uint16_t *x,int n){
+  int i = 0;
+  int count = 0;
+  int maxCount = 0;
+  uint16_t mode = 0;
+  int bimodal;
+  int prevCount = 0;
+  while(i<(n-1)){
+    prevCount=count;
+    count=0;
+    while( x[i]==x[i+1] ) {
+      count++;
+      i++;
+    }
+    if( count > prevCount & count > maxCount) {
+      mode=x[i];
+      maxCount=count;
+      bimodal=0;
+    }
+    if( count == 0 ) {
+      i++;
+    }
+    if( count == maxCount ) {      //If the dataset has 2 or more modes.
+      bimodal=1;
+    }
+    if( mode==0 || bimodal==1 ) {  // Return the median if there is no mode.
+      mode=x[(n/2)];
+    }
+    return mode;
+  }
+}
+

--- a/UnoMaxbotixPulseTimeMode.ino
+++ b/UnoMaxbotixPulseTimeMode.ino
@@ -1,0 +1,163 @@
+/* 
+
+   modified by jec to support maxbotix sensor
+  adding display printouts, and serial monitor is still there.
+   
+   The circuit:
+	* +V to maxbotix to V pin of UNO
+	* GND connection of the maxbotix attached to ground of UNO
+	* AN(analog out) connection of the maxbotix  attached to unconnected as we are using pulse width output
+  * PWO pulse width output connection of the maxbotix  attached to digital pin 7 of UNO
+  * no resistors needed with UNO as it's 5 volt native unless you switch it to 3.3V.
+
+NOTE you must customize the sensor type. The EZ models have different scaling factors than the HRLV models.
+See #ifdef sections in loop
+
+   refer to 
+   https://learn.adafruit.com/trinket-ultrasonic-rangefinder/debugging-and-going-further?view=all
+   https://learn.adafruit.com/ultrasonic-ruler/overview?view=all
+   
+   
+ */
+/* Board settings 
+ *  board: uno
+ *  CPU 80Mhz
+ *  flash: 4M (3M SPIFFS) 
+ *  upload speed: 115200
+ *  programmer AVRISP mkII
+ *  */
+#include <Wire.h>
+extern "C" {
+//#include <user_interface.h>
+}
+
+
+// this constant won't change.  It's the pin number
+// of the sensor's output:
+//const int pingPin = 7;
+const int EZ1pin = 7;  // maxbotix pulse duration pin, see loop() section for different scaling depending on sensor.
+// These values are for calculating a mathematical median for a number of samples as
+// suggested by Maxbotix instead of a mathematical average
+int8_t arraysize = 9; // quantity of values to find the median (sample size). Needs to be an odd number
+//declare an array to store the samples. not necessary to zero the array values here, it just makes the code clearer
+uint16_t rangevalue[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0};
+uint16_t modE;        // calculated median distance
+
+void setup() {
+  
+  // initialize serial communication:
+  Serial.begin(9600);
+  
+  Serial.print("Hello pulse duration Maxbotix ");
+  pinMode(EZ1pin, INPUT); // Set ultrasonic sensor pin as input
+}
+
+
+
+void loop() {
+ 
+  int16_t pulse;  // number of pulses from sensor
+  int i=0;
+  String stringOut = ": ";
+  
+  while( i < arraysize )
+  {                    
+    pulse = pulseIn(EZ1pin, HIGH);  // read in time for pin to transition
+    // ===== EZ such as MB1040, it is 58uS per mm for range up to 6.45m with 1 inch resolution
+    //Pin 2-PW- This pin outputs a pulse width representation of range. 
+    //The distance can be calculated using the scale factor of 147uS per inch.
+    //Pin 3-AN- Outputs analog voltage with a scaling factor of (Vcc/512) per inch. 
+    //A supply of 5V yields ~9.8mV/in. and 3.3V yields ~6.4mV/in. 
+    //The output is buffered and corresponds to the most recent range data.
+    //Change to ZERO if you don't have an EZ model.
+    #if 1   // put 1 here if you using EZ models, and a 0 here if you using HRLV models
+    rangevalue[i]=pulse/58;         // pulses to centimeters =58uS (divide by 147uS for inches)
+    if( rangevalue[i] < 645 && rangevalue[i] >= 15 ) i++;  // ensure no values out of range
+    // ===== HRLV such as 1013, 1023, 1033, it is 1uS per mm for range up to 5000mm with 1mm resolution
+    //Pin 2- Pulse Width Output: This pin outputs a pulse width representation of the distance with a scale factor 
+    //of 1uS per mm. Output range is 300uS for 300-mm to 5000uS for 5000-mm. Pulse width output is +/- 1% of 
+    //the serial data sent.
+    //Pin 3- Analog Voltage Output: On power-up, the voltage on this pin is set to 0V, after which, the voltage on this pin has the voltage corresponding to the latest measured distance. 
+    //This pin outputs an analog voltage scaled representation of the distance with a scale factor of (Vcc/1024) per 5-mm.
+    //Actually, just multiply the number of bits in the value by 5 to yield the range in mm
+    #else
+    rangevalue[i]=pulse / 10;         // pulses to milliimeters =1uS, to cm =/10 (divide by 147uS for inches)
+    if( rangevalue[i] < 500 && rangevalue[i] >= 15 ) i++;  // ensure no values out of range
+    #endif
+    delay(10);                      // wait between samples
+  }
+  isort(rangevalue,arraysize);        // sort samples
+  modE = mode(rangevalue,arraysize);  // get median
+
+
+  Serial.print("distance is: ");
+  stringOut += modE;
+  stringOut += " cm ";
+  Serial.println(stringOut);
+
+  delay(500);                        // Read every half second
+}
+
+
+long microsecondsToInches(long microseconds) {
+  // According to Parallax's datasheet for the PING))), there are
+  // 73.746 microseconds per inch (i.e. sound travels at 1130 feet per
+  // second).  This gives the distance travelled by the ping, outbound
+  // and return, so we divide by 2 to get the distance of the obstacle.
+  // See: http://www.parallax.com/dl/docs/prod/acc/28015-PING-v1.3.pdf
+  return microseconds / 74 / 2;
+}
+
+long microsecondsToCentimeters(long microseconds) {
+  // The speed of sound is 340 m/s or 29 microseconds per centimeter.
+  // The ping travels out and back, so to find the distance of the
+  // object we take half of the distance travelled.
+  return microseconds / 29 / 2;
+}
+
+
+// Sorting function (Author: Bill Gentles, Nov. 12, 2010)
+void isort(uint16_t *a, int8_t n){
+  for (int i = 1; i < n; ++i)  {
+    uint16_t j = a[i];
+    int k;
+    for (k = i - 1; (k >= 0) && (j < a[k]); k--) {
+      a[k + 1] = a[k];
+    }
+    a[k + 1] = j;
+  }
+}
+
+// Mode function, returning the mode or median.
+uint16_t mode(uint16_t *x,int n){
+  int i = 0;
+  int count = 0;
+  int maxCount = 0;
+  uint16_t mode = 0;
+  int bimodal;
+  int prevCount = 0;
+  while(i<(n-1)){
+    prevCount=count;
+    count=0;
+    while( x[i]==x[i+1] ) {
+      count++;
+      i++;
+    }
+    if( count > prevCount & count > maxCount) {
+      mode=x[i];
+      maxCount=count;
+      bimodal=0;
+    }
+    if( count == 0 ) {
+      i++;
+    }
+    if( count == maxCount ) {      //If the dataset has 2 or more modes.
+      bimodal=1;
+    }
+    if( mode==0 || bimodal==1 ) {  // Return the median if there is no mode.
+      mode=x[(n/2)];
+    }
+    return mode;
+  }
+}
+


### PR DESCRIPTION
Adding 2 Uno Sketch files, one for Analog Voltage measurement of distance UnoMaxbotixAnalogMode.ino
and one sketch for Pulse Duration method of distance measurement UnoMaxbotixPulseTimeMode.ino

Both sketches have #if 1 compiler switches in them, to allow you to use either the EZ or HRLV families of Maxbotix ultrasonic distance sensors. Set it to #if 1 to allow the EZ family and #if 0 to use the HRLV family.
The compiler switches are similar to #define or #ifdef #else #endif statements, read up if confused.

EZ sensors I tested with were the MB1040 
HRLV sensor I tested with were the MB1013 MB1023 and MB1033

The reason a compiler switch was used is that the EZ is less precise, and so uses different scaling factor.
Interesting fact is that this code uses the statistical mode/mean functions borrowed from Adafruit, thereby throwing out most extraneous readings.
